### PR TITLE
fix: Correct order replacement and CLI argument handling in noni1aj

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,0 +1,15 @@
+2025-08-18 03:47:00,636 - state_manager - INFO - Loaded state from last_quote_state.json
+2025-08-18 03:47:00,636 - quotes_service - INFO - Quotes service initialized
+2025-08-18 03:47:00,637 - options_service - INFO - Options service initialized
+2025-08-18 03:47:00,644 - stock_orders_service - INFO - Order database initialized
+2025-08-18 03:47:00,644 - stock_orders_service - INFO - Stock orders service initialized
+2025-08-18 03:47:00,645 - option_orders_service - INFO - Option orders service initialized
+2025-08-18 03:47:00,645 - history_service - INFO - History service initialized without Schwab client.
+2025-08-18 03:47:00,646 - state_manager - INFO - Loaded state from last_quote_state.json
+2025-08-18 03:47:00,646 - __main__ - INFO - No credentials or valid tokens found.
+2025-08-18 03:47:00,646 - __main__ - INFO - Server starting without credentials. Use 'initialize_credentials' action to set them.
+2025-08-18 03:47:00,647 - __main__ - ERROR - Server error: [Errno 98] Address already in use
+2025-08-18 03:47:00,647 - __main__ - INFO - Stopping Schwab server...
+2025-08-18 03:47:00,647 - __main__ - INFO - Schwab server stopped
+2025-08-18 03:47:00,647 - __main__ - INFO - Stopping Schwab server...
+2025-08-18 03:47:00,647 - __main__ - INFO - Schwab server stopped


### PR DESCRIPTION
This commit addresses several critical bugs and implements feature enhancements based on user feedback for the `noni1aj.py` trading bot.

Major Changes:

1.  **Fixed Order Replacement Logic:**
    *   The `replace_option_order` call was failing with an "Order instruction cannot be replaced" error.
    *   To resolve this, the logic has been updated to mimic `noni-2/app.py`. Before replacing an order, the bot now fetches the live order details from the API and uses the original `instruction` from that order in the replacement call. This ensures the API receives the request in the expected format.
    *   The shared `client.py` has been restored to its original state where `side` is a required parameter.

2.  **Fixed `--dry-run` Argument Parsing:**
    *   The `--dry-run` CLI argument was previously a simple flag and could not accept a `False` value.
    *   This has been corrected. The argument now accepts a boolean-like value (e.g., 'True', 'False') to explicitly override the `dry-run` setting from the YAML file.

3.  **Standardized `dry-run` Key:**
    *   The rule key has been standardized to `dry-run` in both the validation logic and the sample `.yml` files for consistency.

4.  **Fixed Case-Insensitive Parameter Handling:**
    *   Corrected the logic to ensure that choice-based CLI arguments (e.g., `--prefer-cp`) are properly normalized and override the corresponding rules from the YAML file.

These changes make the application more robust, reliable, and align it more closely with the user's requirements and the behavior of other applications in the repository.